### PR TITLE
Correct back button positions

### DIFF
--- a/resource/ui/charinfopanel.res
+++ b/resource/ui/charinfopanel.res
@@ -118,7 +118,7 @@
 		"ControlName"	"CExButton"
 		"fieldName"		"BackButton"
 		"xpos"			"c-295"
-		"ypos"			"437"
+		"ypos"			"rs1-18"
 		"zpos"			"2"
 		"wide"			"100"
 		"tall"			"26"

--- a/resource/ui/econ/store/v2/storepanel.res
+++ b/resource/ui/econ/store/v2/storepanel.res
@@ -119,7 +119,7 @@
 		"ControlName"	"CExButton"
 		"fieldName"		"CloseButton"
 		"xpos"			"c-295"
-		"ypos"			"437"
+		"ypos"			"rs1-18"
 		"zpos"			"2"
 		"wide"			"100"
 		"tall"			"26"

--- a/resource/ui/replaybrowser/mainpanel.res
+++ b/resource/ui/replaybrowser/mainpanel.res
@@ -118,7 +118,7 @@
 		"ControlName"	"CExButton"
 		"fieldName"		"BackButton"
 		"xpos"			"c-295"
-		"ypos"			"437"
+		"ypos"			"rs1-18"
 		"zpos"			"2"
 		"wide"			"100"
 		"tall"			"26"


### PR DESCRIPTION
Related to #53 and #54.

This changes the position of inventory, store, and replay back buttons to match the main menu's counterpart. Before this change, there is a small pixel difference because it doesn't use the same values (ypos 437 -> rs1-18).