### PR TITLE
Increase chat font size on non-windows platforms

### DIFF
--- a/resource/chatscheme.res
+++ b/resource/chatscheme.res
@@ -361,8 +361,8 @@ Scheme
 			"1"
 			{
 				"name"		"Verdana"
-				"tall"		"12"	[$WIN32]
-				"tall"		"15"	[$X360]
+				"tall"		"12"	[$WINDOWS]
+				"tall"		"15"	[!$WINDOWS]
 				"weight"	"700"
 				"yres"		"480 599"
 				"dropshadow"	"1"
@@ -370,8 +370,8 @@ Scheme
 			"2"
 			{
 				"name"		"Verdana"
-				"tall"		"14"	[$WIN32]
-				"tall"		"17"	[$X360]
+				"tall"		"14"	[$WINDOWS]
+				"tall"		"17"	[!$WINDOWS]
 				"weight"	"700"
 				"yres"		"600 767"
 				"dropshadow"	"1"
@@ -379,8 +379,8 @@ Scheme
 			"3"
 			{
 				"name"		"Verdana"
-				"tall"		"15"	[$WIN32]
-				"tall"		"18"	[$X360]
+				"tall"		"15"	[$WINDOWS]
+				"tall"		"18"	[!$WINDOWS]
 				"weight"	"700"
 				"yres"		"768 1023"
 				"dropshadow"	"1"
@@ -388,8 +388,8 @@ Scheme
 			"4"
 			{
 				"name"		"Verdana"
-				"tall"		"17"	[$WIN32]
-				"tall"		"20"	[$X360]
+				"tall"		"17"	[$WINDOWS]
+				"tall"		"20"	[!$WINDOWS]
 				"weight"	"700"
 				"yres"		"1024 1199"
 				"dropshadow"	"1"
@@ -397,8 +397,8 @@ Scheme
 			"5"
 			{
 				"name"		"Verdana"
-				"tall"		"22"	[$WIN32]
-				"tall"		"25"	[$X360]
+				"tall"		"22"	[$WINDOWS]
+				"tall"		"25"	[!$WINDOWS]
 				"weight"	"700"
 				"yres"		"1200 10000"
 				"dropshadow"	"1"


### PR DESCRIPTION
Hi. Even with Microsoft fonts installed on Linux, the chat font is way too small. This patch bumps the size up to look similar to the Windows version. It doesn't look identical since the Linux version of the game uses a different backend to render fonts, but it's much better. I am unable to test this change on OSX because I lack the hardware.

Default text size:
![image](https://user-images.githubusercontent.com/91440203/179026604-bc5b6bf5-b8fc-45a4-a4df-c611277a41fe.png)

New text size:
![image](https://user-images.githubusercontent.com/91440203/179026682-3b5a2a7a-8b6b-4429-9c44-6146445ddf1f.png)
