### PR TITLE
Move CurrencyStatusPanel to scripts/hudlayout.res

### DIFF
--- a/resource/ui/hudmannvsmachinestatus.res
+++ b/resource/ui/hudmannvsmachinestatus.res
@@ -43,20 +43,6 @@
 		"pin_to_sibling_corner"        "6"
 	}
 
-	"CurrencyStatusPanel"
-	{
-		"ControlName"		"CCurrencyStatusPanel"
-		"fieldName"			"CurrencyStatusPanel"
-		"xpos"				"0"
-		"ypos"				"r100"
-		"wide"				"100"
-		"tall"				"100"
-		"xpos_minmode"		"105"
-		"ypos_minmode"		"r88"
-		"visible" 			"1"
-		"enabled" 			"1"
-	}
-
 	"InWorldCurrencyPanel"
 	{
 		"ControlName"		"CInWorldCurrencyStatus"

--- a/scripts/hudlayout.res
+++ b/scripts/hudlayout.res
@@ -401,6 +401,22 @@
 		"PaintBackgroundType"	"2"
 	}
 
+	CurrencyStatusPanel
+	{
+		"ControlName"		"CCurrencyStatusPanel"
+		"fieldName"			"CurrencyStatusPanel"
+		"xpos"				"0"
+		"ypos"				"r100"
+		"wide"				"100"
+		"tall"				"100"
+		"xpos_minmode"		"105"
+		"ypos_minmode"		"r88"
+		"visible" 			"1"
+		"enabled" 			"1"
+
+		"PaintBackgroundType"	"2"
+	}
+
 	HudProgressBar
 	{
 		"fieldName" "HudProgressBar"


### PR DESCRIPTION
The MvM currency panel stopped showing after this year's Smissmas update because `CurrencyStatusPanel` got moved: https://github.com/Hypnootize/TF2-Default-HUD/commit/1824596664bec02528a3f258d02b7d33d5be246b