### PR TITLE
Fix pomson meter position

### DIFF
--- a/resource/ui/huditemeffectmeter_pomson.res
+++ b/resource/ui/huditemeffectmeter_pomson.res
@@ -6,7 +6,7 @@
 	{
 		"xpos"			"r184"	[$WIN32]
 		"ypos"			"r92"	[$WIN32]
-		"xpos_minmode"	"r42"	[$WIN32]
+		"xpos_minmode"	"r52"	[$WIN32]
 		"ypos_minmode"	"r68"	[$WIN32]
 	}
 }


### PR DESCRIPTION
For minimal hud mode
All other meters are at a small distance from the edge of the screen, with the exception of the pomson.