### PR TITLE
Fix for custom crosshair characters

### DIFF
--- a/resource/ui/#customizations/crosshair/crosshair_scheme.res
+++ b/resource/ui/#customizations/crosshair/crosshair_scheme.res
@@ -172,7 +172,7 @@
 	{
 		"100"
 		{
-			"font"	"resource/ui/#customizations/crosshairs/crosshairs.ttf"
+			"font"	"resource/ui/#customizations/crosshair/crosshairs.ttf"
 			"name"	"TF2Crosshairs"
 		}
 	}


### PR DESCRIPTION
literally just removes one letter to fix custom crosshairs

Before
![20240121233519_1](https://github.com/CriticalFlaw/TF2HUD.Fixes/assets/97610612/c8e50c6d-51de-421b-aaf9-f175b2e69ffe)
After
![20240121233612_1](https://github.com/CriticalFlaw/TF2HUD.Fixes/assets/97610612/827d0cc9-5c1e-4125-8c0a-b58cc843cbd8)
Before
![20240121233516_1](https://github.com/CriticalFlaw/TF2HUD.Fixes/assets/97610612/372d0801-5999-4846-970f-83f6d8156f41)
After
![20240121233315_1](https://github.com/CriticalFlaw/TF2HUD.Fixes/assets/97610612/bb13eed3-94f6-4aa3-bb9e-d4c789c887cb)

