### PR TITLE
Better vote menu fix

### DIFF
--- a/resource/ui/votehud.res
+++ b/resource/ui/votehud.res
@@ -534,7 +534,7 @@
 		"fieldName"			"VoteSetupDialog"
 		"xpos"				"c-200"
 		"ypos"				"c-150"
-		"wide"				"420"
+		"wide"				"400"
 		"tall"				"310"
 		"autoResize"		"0"
 		"pinCorner"			"0"
@@ -554,7 +554,7 @@
 		"issue_fgcolor"		"TanLight"
 		"issue_fgcolor_disabled"	"TanDark"
 		
-		"parameter_width"	"200"
+		"parameter_width"	"168"
 
 		"TitleLabel"
 		{
@@ -599,7 +599,7 @@
 			"xpos"		"190"
 			"ypos"		"38"
 			"zpos"		"2"
-			"wide"		"227"
+			"wide"		"200"
 			"tall"		"200"
 			"pinCorner"		"0"
 			"visible"		"1"


### PR DESCRIPTION
"parameter_width" saved us! (still leaves empty space when there's no scrollbar, but it's still better than the old solution)
![votemenu](https://github.com/CriticalFlaw/TF2HUD.Fixes/assets/117596825/a164e4c1-c1ad-4f1b-a03c-d33dbe847fde)