### PR TITLE
Fixed spell panel dots being cutoff

### DIFF
--- a/resource/ui/hudspellselection.res
+++ b/resource/ui/hudspellselection.res
@@ -118,7 +118,7 @@
 		"xpos_minmode"	"46"
 		"ypos_minmode"	"37"
 		"wide"			"20"
-		"tall"			"19"
+		"tall"			"20"
 		"fgcolor"		"tanlight"
 	}
 }


### PR DESCRIPTION
Before:
![spelldotsbroken](https://github.com/CriticalFlaw/TF2HUD.Fixes/assets/117596825/60cfca4c-f9a6-4b04-a1c4-c87faee230b1)
After:
![spelldotsfixed](https://github.com/CriticalFlaw/TF2HUD.Fixes/assets/117596825/0d6a1a43-c0ad-494d-b56e-b01be60af4b1)