### PR TITLE
Moved player destruction carried container in minmode

### DIFF
--- a/resource/ui/hudobjectiveplayerdestruction.res
+++ b/resource/ui/hudobjectiveplayerdestruction.res
@@ -122,7 +122,7 @@
 		"fieldName"			"CarriedContainer"
 		"xpos"				"0"
 		"ypos"				"r100"
-		"xpos_minmode"	    "124"
+		"xpos_minmode"	    "125"
 		"ypos_minmode"	    "r90"
 		"zpos"				"1"
 		"wide"				"100"

--- a/resource/ui/hudobjectiveplayerdestruction.res
+++ b/resource/ui/hudobjectiveplayerdestruction.res
@@ -122,6 +122,7 @@
 		"fieldName"			"CarriedContainer"
 		"xpos"				"0"
 		"ypos"				"r100"
+		"xpos_minmode"	    "124"
 		"ypos_minmode"	    "r90"
 		"zpos"				"1"
 		"wide"				"100"


### PR DESCRIPTION
To match the position of the money counter in mvm (minmode)

MvM:
![pdfixmvm](https://github.com/CriticalFlaw/TF2HUD.Fixes/assets/117596825/8e8b8f6d-b832-4bdb-8903-a0ebd4cbb3a4)
Before:
![pdbroken](https://github.com/CriticalFlaw/TF2HUD.Fixes/assets/117596825/6d833fc1-d47c-442b-9b73-bfa0f62adc81)
After:
![pdfixed](https://github.com/CriticalFlaw/TF2HUD.Fixes/assets/117596825/36179f17-c598-4e30-a99d-7c65a89b7078)