### PR TITLE
Fixed overlapping of long names

### DIFF
--- a/resource/ui/pvprankpanel.res
+++ b/resource/ui/pvprankpanel.res
@@ -208,7 +208,7 @@
 			"fieldName"		"NameLabel"
 			"xpos"			"65"
 			"ypos"			"5"
-			"wide"			"f0"
+			"wide"			"170"
 			"zpos"			"100"
 			"tall"			"20"
 			"visible"		"1"

--- a/resource/ui/scoreboard.res
+++ b/resource/ui/scoreboard.res
@@ -719,7 +719,7 @@
 		"xpos"			"115"
 		"ypos"			"377"
 		"zpos"			"3"
-		"wide"			"300"
+		"wide"			"200"
 		"tall"			"20"
 		"autoResize"	"0"
 		"pinCorner"		"0"


### PR DESCRIPTION
Before:
![longnamebroken](https://github.com/CriticalFlaw/TF2HUD.Fixes/assets/117596825/2b1f7019-a6c0-45a8-a609-765da804d71b)
After:
![longnamefixed](https://github.com/CriticalFlaw/TF2HUD.Fixes/assets/117596825/6bf3a91f-0a21-4177-bb2a-2234f7ee2475)

Before:
![scoreboardlongnamebroken](https://github.com/CriticalFlaw/TF2HUD.Fixes/assets/117596825/ed1d1964-052b-41cc-b5cc-39e3e993addf)
After:
![scoreboardlongnamefixed](https://github.com/CriticalFlaw/TF2HUD.Fixes/assets/117596825/a4de675e-9294-492a-8f01-dc05d51cd01d)