### PR TITLE
Fixed stats cutoffs in linux

### DIFF
--- a/resource/ui/pvprankpanel.res
+++ b/resource/ui/pvprankpanel.res
@@ -459,7 +459,8 @@
 					"xpos"			"10"
 					"ypos"			"5"
 					"zpos"			"0"
-					"wide"			"100"
+					"wide"			"100" [$WINDOWS]
+					"wide"			"110" [$LINUX]
 					"tall"			"20"
 					"visible"		"1"
 					"enabled"		"1"
@@ -477,7 +478,8 @@
 					"xpos"			"10"
 					"ypos"			"25"
 					"zpos"			"0"
-					"wide"			"100"
+					"wide"			"100" [$WINDOWS]
+					"wide"			"110" [$LINUX]
 					"tall"			"20"
 					"visible"		"1"
 					"enabled"		"1"
@@ -495,7 +497,8 @@
 					"xpos"			"10"
 					"ypos"			"45"
 					"zpos"			"0"
-					"wide"			"100"
+					"wide"			"100" [$WINDOWS]
+					"wide"			"110" [$LINUX]
 					"tall"			"20"
 					"visible"		"1"
 					"enabled"		"1"
@@ -514,7 +517,8 @@
 					"xpos"			"c0"
 					"ypos"			"5"
 					"zpos"			"0"
-					"wide"			"100"
+					"wide"			"100" [$WINDOWS]
+					"wide"			"121" [$LINUX]
 					"tall"			"20"
 					"visible"		"1"
 					"enabled"		"1"
@@ -532,7 +536,8 @@
 					"xpos"			"c0"
 					"ypos"			"25"
 					"zpos"			"0"
-					"wide"			"100"
+					"wide"			"100" [$WINDOWS]
+					"wide"			"121" [$LINUX]
 					"tall"			"20"
 					"visible"		"1"
 					"enabled"		"1"
@@ -569,7 +574,8 @@
 					"xpos"			"c0"
 					"ypos"			"45"
 					"zpos"			"0"
-					"wide"			"100"
+					"wide"			"100" [$WINDOWS]
+					"wide"			"121" [$LINUX]
 					"tall"			"20"
 					"visible"		"1"
 					"enabled"		"1"


### PR DESCRIPTION
Before:
![statslinuxbroken](https://github.com/CriticalFlaw/TF2HUD.Fixes/assets/117596825/e026dd87-de08-434c-a88f-03d3320e52fe)
After:
![statslinuxfixed](https://github.com/CriticalFlaw/TF2HUD.Fixes/assets/117596825/45e31e99-671e-46ae-9147-aba03f5c4be3)