### PR TITLE
Fixes to fonts on Linux

### DIFF
--- a/resource/clientscheme.res
+++ b/resource/clientscheme.res
@@ -781,6 +781,7 @@ Scheme
 			"1"
 			{
 				"name"		"TF2"
+				"tall"		"23"	[$LINUX]
 				"tall"		"24"
 				"tall_lodef"	"80"
 				"weight"	"500"
@@ -791,6 +792,7 @@ Scheme
 			"2"
 			{
 				"name"		"TF2"
+				"tall"		"31"	[$LINUX]
 				"tall"		"32"
 				"tall_hidef"	"120"
 				"weight"	"500"
@@ -801,6 +803,7 @@ Scheme
 			"3"
 			{
 				"name"		"TF2"
+				"tall"		"43"	[$LINUX]
 				"tall"		"44"
 				"weight"	"500"
 				"additive"	"0"
@@ -810,6 +813,7 @@ Scheme
 			"4"
 			{
 				"name"		"TF2"
+				"tall"		"47"	[$LINUX]
 				"tall"		"48"
 				"weight"	"500"
 				"additive"	"0"
@@ -819,6 +823,7 @@ Scheme
 			"5"
 			{
 				"name"		"TF2"
+				"tall"		"51"	[$LINUX]
 				"tall"		"52"
 				"weight"	"500"
 				"additive"	"0"
@@ -831,6 +836,7 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Build"
+				"tall"		"43"	[$LINUX]
 				"tall"		"44"
 				"tall_lodef"	"52"
 				"weight"	"500"
@@ -844,6 +850,7 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Build"
+				"tall"		"34"	[$LINUX]
 				"tall"		"35"
 				"tall_lodef"	"40"
 				"weight"	"500"
@@ -857,6 +864,7 @@ Scheme
 			"1"
 			{
 				"name"		"TF2"
+				"tall"		"35"	[$LINUX]
 				"tall"		"36"
 				"tall_hidef"	"48"
 				"weight"	"500"
@@ -869,6 +877,7 @@ Scheme
 			"1"
 			{
 				"name"		"TF2"
+				"tall"		"29"	[$LINUX]
 				"tall"		"30"
 				"weight"	"500"
 				"additive"	"0"
@@ -880,6 +889,7 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Build"
+				"tall"		"29"	[$LINUX]
 				"tall"		"30"
 				"weight"	"500"
 				"additive"	"0"
@@ -891,6 +901,7 @@ Scheme
 			"1"
 			{
 				"name"		"TF2"
+				"tall"		"23"	[$LINUX]
 				"tall"		"24"
 				"tall_lodef"		"28"
 				"weight"	"500"
@@ -903,6 +914,7 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Secondary"
+				"tall"		"23"	[$LINUX]
 				"tall"		"24"
 				"weight"	"500"
 				"additive"	"0"
@@ -914,6 +926,7 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Build"
+				"tall"		"23"	[$LINUX]
 				"tall"		"24"
 				"weight"	"500"
 				"additive"	"0"
@@ -925,6 +938,7 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Build"
+				"tall"		"17"	[$LINUX]
 				"tall"		"18"
 				"weight"	"500"
 				"additive"	"0"
@@ -936,6 +950,7 @@ Scheme
 			"1"
 			{
 				"name"		"TF2"
+				"tall"		"17"	[$LINUX]
 				"tall"		"18"
 				"tall_hidef"	"24"
 				"tall_lodef"	"18"
@@ -949,6 +964,7 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Secondary"
+				"tall"		"17"	[$LINUX]
 				"tall"		"18"
 				"tall_hidef"	"24"
 				"tall_lodef"	"20"
@@ -962,6 +978,7 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Secondary"
+				"tall"		"13"	[$LINUX]
 				"tall"		"14"
 				"tall_lodef"	"16"
 				"weight"	"500"
@@ -974,6 +991,7 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Build"
+				"tall"		"15"	[$LINUX]
 				"tall"		"16"
 				"weight"	"500"
 				"additive"	"0"
@@ -985,6 +1003,7 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Build"
+				"tall"		"13"	[$LINUX]
 				"tall"		"14"
 				"weight"	"500"
 				"additive"	"0"
@@ -996,6 +1015,7 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Build"
+				"tall"		"13"	[$LINUX]
 				"tall"		"14"
 				"weight"	"500"
 				"additive"	"0"
@@ -1042,6 +1062,7 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Secondary"
+				"tall"		"14"	[$LINUX]
 				"tall"		"15"
 				"weight"	"500"
 				"additive"	"0"
@@ -1075,6 +1096,7 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Build"
+				"tall"		"15"	[$LINUX]
 				"tall"		"16"
 				"weight"	"500"
 				"additive"	"0"
@@ -1207,6 +1229,7 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Secondary"
+				"tall"		"17"	[$LINUX]
 				"tall"		"18"
 				"tall_hidef"	"24"
 				"tall_lodef"	"18"
@@ -1220,6 +1243,7 @@ Scheme
 			"1"
 			{
 				"name"		"TF2"
+				"tall"		"15"	[$LINUX]
 				"tall"		"16"
 				"tall_hidef"	"22"
 				"tall_lodef"	"22"
@@ -1280,6 +1304,7 @@ Scheme
 			"1"
 			{
 				"name"		"TF2"
+				"tall"		"14"	[$LINUX]
 				"tall"		"15"
 				"weight"	"700"
 				"antialias" 	"1"
@@ -1290,6 +1315,7 @@ Scheme
 			"2"
 			{
 				"name"		"TF2"
+				"tall"		"14"	[$LINUX]
 				"tall"		"15"	[$WIN32]
 				"tall"		"21"	[$X360]
 				"weight"	"700"
@@ -1301,6 +1327,7 @@ Scheme
 			"3"
 			{
 				"name"		"TF2"
+				"tall"		"17"	[$LINUX]
 				"tall"		"18"
 				"weight"	"900"
 				"antialias" 	"1"
@@ -1310,6 +1337,7 @@ Scheme
 			"4"
 			{
 				"name"		"TF2"
+				"tall"		"20"	[$LINUX]
 				"tall"		"21"
 				"weight"	"900"
 				"antialias" 	"1"
@@ -1319,6 +1347,7 @@ Scheme
 			"5"
 			{
 				"name"		"TF2"
+				"tall"		"23"	[$LINUX]
 				"tall"		"24"
 				"weight"	"1000"
 				"antialias" 	"1"
@@ -1385,6 +1414,7 @@ Scheme
 			"1"
 			{
 				"name"  "Team Fortress" // tf.ttf
+				"tall"	"27"	[$LINUX]
 				"tall"  "28"
 				"weight" "0"
 				"additive" "1"
@@ -1485,6 +1515,7 @@ Scheme
 			"1"
 			{
 				"name"		"TF2"
+				"tall"		"23"	[$LINUX]
 				"tall"		"24"
 				"antialias" "1"
 				"weight"	"500"
@@ -1531,6 +1562,7 @@ Scheme
 			"1"
 			{
 				"name"			"TF2 Professor"
+				"tall"			"27"	[$LINUX]
 				"tall"			"28"
 				"tall_lodef"	"48"
 				"tall_hidef"	"48"
@@ -1546,6 +1578,7 @@ Scheme
 			"1"
 			{
 				"name"			"TF2 Professor"
+				"tall"			"39"	[$LINUX]
 				"tall"			"40"
 				"tall_lodef"	"48"
 				"tall_hidef"	"48"
@@ -1561,6 +1594,7 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Professor"
+				"tall"		"23"	[$LINUX]
 				"tall"		"24"
 				"tall_lodef"	"36"
 				"tall_hidef"	"36"
@@ -1637,6 +1671,7 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Secondary"
+				"tall"		"19"	[$LINUX]
 				"tall"		"20"
 				"weight"	"500"
 				"range"		"0x0000 0x007F"	//	Basic Latin
@@ -1649,6 +1684,7 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Secondary"
+				"tall"		"19"	[$LINUX]
 				"tall"		"20"
 				"tall_hidef"	"24"
 				"tall_lodef"	"24"
@@ -1675,6 +1711,7 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Secondary"
+				"tall"		"19"	[$LINUX]
 				"tall"		"20"
 				"weight"	"500"
 				"range"		"0x0000 0x007F"	//	Basic Latin
@@ -1687,6 +1724,7 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Secondary"
+				"tall"		"33"	[$LINUX]
 				"tall"		"34"
 				"tall_hidef"	"38"
 				"tall_lodef"	"38"
@@ -1702,6 +1740,7 @@ Scheme
 			"1"
 			{
 				"name"		"TF2"
+				"tall"		"35"	[$LINUX]
 				"tall"		"36"
 				"tall_hidef"	"48"
 				"weight"	"500"
@@ -1714,6 +1753,7 @@ Scheme
 			"1"
 			{
 				"name"		"TF2"
+				"tall"		"51"	[$LINUX]
 				"tall"		"52"
 				"tall_lodef"		"80"
 				"range" 	"0x0000 0x00FF"
@@ -1724,6 +1764,7 @@ Scheme
 			"2"
 			{
 				"name"		"TF2"
+				"tall"		"71"	[$LINUX]
 				"tall"		"72"
 				"tall_hidef"	"120"
 				"range" 	"0x0000 0x00FF"
@@ -1734,6 +1775,7 @@ Scheme
 			"3"
 			{
 				"name"		"TF2"
+				"tall"		"99"	[$LINUX]
 				"tall"		"100"
 				"range" 	"0x0000 0x00FF"
 				"weight"	"400"
@@ -1743,6 +1785,7 @@ Scheme
 			"4"
 			{
 				"name"		"TF2"
+				"tall"		"139"	[$LINUX]
 				"tall"		"140"
 				"range" 	"0x0000 0x00FF"
 				"weight"	"400"
@@ -1752,6 +1795,7 @@ Scheme
 			"5"
 			{
 				"name"		"TF2"
+				"tall"		"179"	[$LINUX]
 				"tall"		"180"
 				"range" 	"0x0000 0x00FF"
 				"weight"	"400"
@@ -1764,6 +1808,7 @@ Scheme
 			"1"
 			{
 				"name"		"TF2"
+				"tall"		"35"	[$LINUX]
 				"tall"		"36"
 				"weight"	"500"
 				"range"		"0x0000 0x007F"	//	Basic Latin
@@ -1787,6 +1832,7 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Secondary"
+				"tall"		"19"	[$LINUX]
 				"tall"		"20"
 				"weight"	"400"
 				"additive"	"0"
@@ -1913,6 +1959,7 @@ Scheme
 			"4"
 			{
 				"name"		"Verdana"
+				"tall"		"19"	[$LINUX]
 				"tall"		"20"
 				"weight"	"700"
 				"yres"		"1024 1199"
@@ -1921,6 +1968,7 @@ Scheme
 			"5"
 			{
 				"name"		"Verdana"
+				"tall"		"23"	[$LINUX]
 				"tall"		"24"
 				"weight"	"700"
 				"yres"		"1200 10000"
@@ -2067,6 +2115,7 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Build"
+				"tall"		"35"	[$LINUX]
 				"tall"		"36"
 				"tall_lodef"		"28"
 				"weight"	"500"
@@ -2077,6 +2126,7 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Build"
+				"tall"		"29"	[$LINUX]
 				"tall"		"30"
 				"tall_lodef"		"22"
 				"weight"	"500"
@@ -2087,6 +2137,7 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Secondary"
+				"tall"		"27"	[$LINUX]
 				"tall"		"28"
 				"tall_lodef"	"24"
 				"weight"	"500"
@@ -2115,6 +2166,7 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Secondary"
+				"tall"		"21"	[$LINUX]
 				"tall"		"22"
 				"weight"	"500"
 			}
@@ -2124,6 +2176,7 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Secondary"
+				"tall"		"17"	[$LINUX]
 				"tall"		"18"
 				"weight"	"500"
 			}
@@ -2163,6 +2216,7 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Build"
+				"tall"		"35"	[$LINUX]
 				"tall"		"36"
 				"weight"	"500"
 				"additive"	"0"
@@ -2185,6 +2239,7 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Secondary"
+				"tall"		"17"	[$LINUX]
 				"tall"		"18"
 				"weight"	"400"
 				"additive"	"0"
@@ -2304,6 +2359,7 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Build"
+				"tall"		"17"	[$LINUX]
 				"tall"		"18"
 				"weight"	"500"
 				"additive"	"0"
@@ -2315,6 +2371,7 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Secondary"
+				"tall"		"6"	[$LINUX]
 				"tall"		"7"
 				"weight"	"500"
 				"additive"	"0"
@@ -2336,6 +2393,7 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Secondary"
+				"tall"		"7"	[$LINUX]
 				"tall"		"8"
 				"weight"	"500"
 				"additive"	"0"
@@ -2529,6 +2587,7 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Professor"
+				"tall"		"19"	[$LINUX]
 				"tall"		"20"
 				"antialias" "1"
 				"custom"		"1" [$OSX]
@@ -2559,6 +2618,7 @@ Scheme
 			"3"
 			{
 				"name"		"TF2 Secondary"
+				"tall"		"21"	[$LINUX]
 				"tall"		"22"
 				"weight"	"400"
 				"additive"	"0"
@@ -2592,6 +2652,7 @@ Scheme
 			"3"
 			{
 				"name"		"TF2 Secondary"
+				"tall"		"21"	[$LINUX]
 				"tall"		"22"
 				"weight"	"400"
 				"additive"	"0"
@@ -2624,6 +2685,7 @@ Scheme
 			"3"
 			{
 				"name"		"TF2 Secondary"
+				"tall"		"17"	[$LINUX]
 				"tall"		"18"
 				"weight"	"800"
 				"additive"	"0"
@@ -2649,6 +2711,7 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Secondary"
+				"tall"		"15"	[$LINUX]
 				"tall"		"16"
 				"weight"	"400"
 				"additive"	"0"
@@ -2855,6 +2918,7 @@ Scheme
 			"1"
 			{
 				"name"		"TF2"
+				"tall"		"17"	[$LINUX]
 				"tall"		"18"
 				"tall_hidef"	"24"
 				"tall_lodef"	"18"
@@ -2868,6 +2932,7 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Build"
+				"tall"		"23"	[$LINUX]
 				"tall"		"24"
 				"weight"	"500"
 				"additive"	"0"
@@ -2879,6 +2944,7 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Secondary"
+				"tall"		"17"	[$LINUX]
 				"tall"		"18"
 				"tall_hidef"	"24"
 				"tall_lodef"	"20"
@@ -2907,6 +2973,7 @@ Scheme
 			"1"
 			{
 				"name"		"TF2 Build"
+				"tall"		"23"	[$LINUX]
 				"tall"		"24"
 				"weight"	"500"
 				"additive"	"0"


### PR DESCRIPTION
Adjusts the TF2 fonts to be smaller to fix issues with fonts getting cutoff on Linux. Still doing some testing on this, just putting this here if someone else wants to test it

Before and after examples:
![before](https://github.com/CriticalFlaw/TF2HUD.Fixes/assets/97610612/5ac2ae86-930d-46f1-87a0-74a01ffba137)
![after](https://github.com/CriticalFlaw/TF2HUD.Fixes/assets/97610612/578f7fc0-9489-45bb-9e40-fde2dd210907)
![before2](https://github.com/CriticalFlaw/TF2HUD.Fixes/assets/97610612/17243432-22a0-49e5-9cd5-f0b7b360db50)
![after2](https://github.com/CriticalFlaw/TF2HUD.Fixes/assets/97610612/b7c2b966-7308-4b83-9552-87b8996db5a0)
