### PR TITLE
Visual tweaks to the pre-match screen

### DIFF
--- a/resource/ui/hudmatchstatus.res
+++ b/resource/ui/hudmatchstatus.res
@@ -710,22 +710,22 @@
 			"ControlName"	"SectionedListPanel"
 			"fieldName"		"BluePlayerList"
 			"xpos"			"6"
-			"ypos"			"38"
+			"ypos"			"40"
 			"zpos"			"1"
 			"wide"			"136"
-			"tall"			"175"
+			"tall"			"163"
 			"pinCorner"		"0"
 			"visible"		"1"
 			"enabled"		"1"
 			"tabPosition"	"0"
 			"autoresize"	"3"
-			"linespacing"	"25"
-			"linegap"		"0"
+			"linespacing"	"21"
+			"linegap"		"4"
 			//"show_columns"	"1"
 
 			if_large
 			{
-				"tall"			"315"
+				"tall"			"312"
 			}
 		}
 		"BluePlayerListBG"
@@ -736,7 +736,7 @@
 			"ypos"			"30"
 			"zpos"			"0"
 			"wide"			"139"
-			"tall"			"215"
+			"tall"			"176"
 			"autoResize"	"0"
 			"pinCorner"		"0"
 			"visible"		"1"
@@ -848,22 +848,22 @@
 			"ControlName"	"SectionedListPanel"
 			"fieldName"		"RedPlayerList"
 			"xpos"			"6"
-			"ypos"			"38"
+			"ypos"			"40"
 			"zpos"			"1"
 			"wide"			"136"
-			"tall"			"175"
+			"tall"			"163"
 			"pinCorner"		"0"
 			"visible"		"1"
 			"enabled"		"1"
 			"tabPosition"	"0"
 			"autoresize"	"3"
-			"linespacing"	"25"
-			"linegap"		"0"
+			"linespacing"	"21"
+			"linegap"		"4"
 			//"show_columns"	"1"
 
 			if_large
 			{
-				"tall"			"315"
+				"tall"			"312"
 			}
 		}
 		"RedPlayerListBG"
@@ -874,7 +874,7 @@
 			"ypos"			"30"
 			"zpos"			"0"
 			"wide"			"139"
-			"tall"			"215"
+			"tall"			"176"
 			"autoResize"	"0"
 			"pinCorner"		"0"
 			"visible"		"1"


### PR DESCRIPTION
As you may recall, the past values were taken from flawhud without modification and therefore do not match the style of the default hud

This PR fixes that

Before:
![image](https://github.com/CriticalFlaw/TF2HUD.Fixes/assets/117596825/8afcf0df-3ce0-44e3-ad6b-eaf561908f24)
After:
![tweakedprelist](https://github.com/CriticalFlaw/TF2HUD.Fixes/assets/117596825/92b8f9f4-4c94-4c6c-9bf6-c2b8680c2001)