### PR TITLE
Adjusted bonus health size for 1920x1080 resolution

### DIFF
--- a/resource/ui/hudplayerhealth.res
+++ b/resource/ui/hudplayerhealth.res
@@ -16,7 +16,7 @@
 		"tall"			"120"
 		"visible"		"1"
 		"enabled"		"1"	
-		"HealthBonusPosAdj"	"35"
+		"HealthBonusPosAdj"	"74"
 		"HealthDeathWarning"	"0.49"
 		"HealthDeathWarningColor"	"HUDDeathWarning"
 	}	


### PR DESCRIPTION
Before:
![bonushealthbefore](https://github.com/CriticalFlaw/TF2HUD.Fixes/assets/117596825/0f4e9c3a-c144-4e6b-9c52-4c71edef2c27)
After:
![bonushealthafter](https://github.com/CriticalFlaw/TF2HUD.Fixes/assets/117596825/bfa30feb-78fd-4010-93fd-96b6be0f2446)