### PR TITLE
Fix for the Selbyen HUD icons in casual

### DIFF
--- a/resource/ui/selbyenhud.res
+++ b/resource/ui/selbyenhud.res
@@ -5,7 +5,7 @@
 	{
 		 "CarriedImage"
 		 {
-			 "image"                                             "../vgui/replay/thumbnails/selbyen_pickup"
+			 "image"	"replay/thumbnails/selbyen_pickup"
 		 }
 	}
 	"ScoreContainer"
@@ -14,12 +14,12 @@
 		 {
 			 "FlagImageBlue"
 			 {
-					 "image"                                             "../vgui/replay/thumbnails/selbyen_pickup"
+					 "image"	"replay/thumbnails/selbyen_pickup"
 					 "zpos"			"100"
 			 }
 			 "FlagImageRed"
 			 {
-					 "image"                                             "../vgui/replay/thumbnails/selbyen_pickup"
+					 "image"	"replay/thumbnails/selbyen_pickup"
 					 "zpos"			"100"
 			 }
 		 }


### PR DESCRIPTION
Before and After
![pd_selbyen0001](https://github.com/CriticalFlaw/TF2HUD.Fixes/assets/97610612/5664bb06-4a51-4f10-8de9-c7284ae1bb09)