### PR TITLE
Fix arena alive player count being overlapped by the spectator HUD

### DIFF
--- a/scripts/hudlayout.res
+++ b/scripts/hudlayout.res
@@ -1209,6 +1209,7 @@
 		"enabled"				"1"
 		"xpos"					"0"
 		"ypos"					"0"
+		"zpos"					"1"
 		"wide"					"f0"
 		"tall"					"100"
 	}


### PR DESCRIPTION
Before and After
![arena_badlands0000](https://github.com/CriticalFlaw/TF2HUD.Fixes/assets/97610612/db76e840-7157-49e4-9782-8601909b74cc)
