### PR TITLE
Fixed status icons overlapping max health (again)

### DIFF
--- a/resource/ui/hudplayerhealth.res
+++ b/resource/ui/hudplayerhealth.res
@@ -7,13 +7,13 @@
 		"fieldName"		"HudPlayerHealth"
 		"xpos"			"0"		[$WIN32]
 		"xpos_minmode"	"-5"		[$WIN32]
-		"ypos"			"r125"	[$WIN32]
-		"ypos_minmode"	"rs0.743"	[$WIN32]
+		"ypos"			"r130"	[$WIN32]
+		"ypos_minmode"	"rs0.753"	[$WIN32]
 		"xpos"			"32"	[$X360]
 		"ypos"			"r144"	[$X360]
 		"zpos"			"2"
 		"wide"			"250"
-		"tall"			"125"
+		"tall"			"130"
 		"visible"		"1"
 		"enabled"		"1"	
 		"HealthBonusPosAdj"	"35"
@@ -26,7 +26,7 @@
 		"fieldName"		"PlayerStatusHealthImage"
 		"xpos"			"75"
 		"xpos_minmode"	"60"
-		"ypos"			"40"
+		"ypos"			"45"
 		"zpos"			"4"
 		"wide"			"51"
 		"tall"			"51"
@@ -40,7 +40,7 @@
 		"fieldName"		"PlayerStatusHealthImageBG"
 		"xpos"			"73"
 		"xpos_minmode"	"58"
-		"ypos"			"38"
+		"ypos"			"43"
 		"zpos"			"3"
 		"wide"			"55"
 		"tall"			"55"
@@ -56,8 +56,8 @@
 		"xpos"			"73"	[$WIN32]
 		"xpos_minmode"	"65"	[$WIN32]
 		"xpos"			"83"	[$X360]
-		"ypos"			"38"	[$WIN32]
-		"ypos_minmode"	"45"	[$WIN32]
+		"ypos"			"43"	[$WIN32]
+		"ypos_minmode"	"50"	[$WIN32]
 		"ypos"			"43"	[$X360]
 		"zpos"			"2"
 		"wide"			"55"	[$WIN32]
@@ -77,7 +77,7 @@
 		"fieldName"		"PlayerStatusHealthValue"
 		"xpos"			"76"
 		"xpos_minmode"	"61"
-		"ypos"			"57"	[$WIN32]
+		"ypos"			"62"	[$WIN32]
 		"ypos"			"55"	[$X360]
 		"zpos"			"5"
 		"wide"			"50"
@@ -95,7 +95,7 @@
 		"fieldName"		"PlayerStatusMaxHealthValue"
 		"xpos"			"76"
 		"xpos_minmode"	"61"
-		"ypos"			"25"	[$WIN32]
+		"ypos"			"30"	[$WIN32]
 		"ypos"			"55"	[$X360]
 		"zpos"			"6"
 		"wide"			"50"


### PR DESCRIPTION
Closes #214 
All the other status icons don't overlap the max health, except for Mad Milk, so I had to move the status icons up a bit more again