### PR TITLE
Fixed match status overlapping respawn time in minmode and 4:3

### DIFF
--- a/resource/ui/spectator.res
+++ b/resource/ui/spectator.res
@@ -71,15 +71,12 @@
 		"ControlName"		"CExLabel"
 		"fieldName"		"ReinforcementsLabel"
 		"xpos"			"c-300"	[$WIN32]
-		"xpos_minmode"	"0"
 		"xpos"			"c-200"	[$X360]
 		"ypos"			"80"	[$WIN32]
-		"ypos_minmode"	"3"		[$WIN32]
 		"ypos"			"67"	[$X360]
 		"ypos_hidef"	"79"
 		"ypos_lodef"	"85"
 		"wide"			"600"	[$WIN32]
-		"wide_minmode"	"300"
 		"wide"			"400"	[$X360]
 		"tall"			"18"
 		"tall_hidef"		"23"
@@ -89,7 +86,6 @@
 		"enabled"		"1"
 		"labelText"		"#game_respawntime_in_secs"
 		"textAlignment"		"center"
-		"textAlignment_minmode"		"west"
 		"use_proportional_insets_minmode"	"1"
 		"textinsetx_minmode"				"5"
 		"font"			"HudFontMediumSmallSecondary"


### PR DESCRIPTION
Minmode and 4:3

Before:
![fixrespawntimeoverlapminmode4-3before](https://github.com/CriticalFlaw/TF2HUD.Fixes/assets/117596825/1f0bc9ee-60f8-42cd-bdef-2191188a701c)
After:
![fixrespawntimeoverlapminmode4-3after](https://github.com/CriticalFlaw/TF2HUD.Fixes/assets/117596825/56ad5dfd-2eb4-40e6-b99f-48c82485698c)