### PR TITLE
Fixed timer overlapping player panels

### DIFF
--- a/resource/ui/spectatortournament.res
+++ b/resource/ui/spectatortournament.res
@@ -10,11 +10,11 @@
 		"pinCorner"		"0"
 		"enabled"		"1"
 				
-		"team1_player_base_offset_x"		"-75"
+		"team1_player_base_offset_x"		"-85"
 		"team1_player_base_y"				"0"
 		"team1_player_delta_x"				"-47"
 		"team1_player_delta_y"				"0"
-		"team2_player_base_offset_x"		"25"
+		"team2_player_base_offset_x"		"35"
 		"team2_player_base_y"				"0"
 		"team2_player_delta_x"				"47"
 		"team2_player_delta_y"				"0"


### PR DESCRIPTION
before
![timerplayerpanelbefore](https://github.com/CriticalFlaw/TF2HUD.Fixes/assets/117596825/096335c2-326e-4c4d-b44d-24461586d650)
after
![timerplayerpanelsafter](https://github.com/CriticalFlaw/TF2HUD.Fixes/assets/117596825/5b4ed28d-46be-4bf2-82c1-41345784c337)