### PR TITLE
Revert "Fixed #207"

### DIFF
--- a/resource/ui/hudplayerclass.res
+++ b/resource/ui/hudplayerclass.res
@@ -88,8 +88,8 @@
 	{
 		"ControlName"			"EditablePanel"
 		"fieldName"				"CarryingWeapon"
-		"xpos"					"15"
-		"xpos_minmode"			"0"
+		"xpos"					"20"
+		"xpos_minmode"			"90"
 		"ypos"					"r27"
 		"ypos_minmode"			"r36"
 		"zpos"					"100"


### PR DESCRIPTION
This reverts commit 73f14b35312811e1ace195eb49716a09512ffa77.

What we've done doesn't work.

The most logical solution would be to make this panel a separate element and have it cover everything underneath it, but without Valve that's not possible

![revertkillstreak](https://github.com/CriticalFlaw/TF2HUD.Fixes/assets/117596825/bb1df28e-b9f2-4633-86cc-39c860f3f677)