### PR TITLE
Fixed queue status overlapping match status (again)

### DIFF
--- a/resource/ui/hudmatchsummary.res
+++ b/resource/ui/hudmatchsummary.res
@@ -8,7 +8,7 @@
 		"pinCorner"		"0"
 		"tabPosition"	"0"
 		"paintbackground"	"0"
-		"zpos"			"1003"
+		"zpos"			"20"
 		"visible"		"0"
 
 		"AnimBluePlayerListParent"		"p.47"

--- a/resource/ui/ingamequeuestatus.res
+++ b/resource/ui/ingamequeuestatus.res
@@ -1,0 +1,55 @@
+"Resource/UI/InGameQueueStatus.res"
+{
+	"QueueHUDStatus"
+	{
+		"fieldName"				"QueueHUDStatus"
+		"visible"				"1"
+		"enabled"				"1"
+		"xpos"					"rs1-5"
+		"ypos"					"1"
+		"zpos"					"1001"
+		"wide"					"200"
+		"tall"					"18"
+		"proportionaltoparent"	"1"
+		"keyboardinputenabled"	"1"
+		"mouseinputenabled"		"0"
+		"alpha"					"100"
+	}
+
+	"CTFLogoPanel"
+	{
+		"ControlName"	"CTFLogoPanel"
+		"fieldname"		"CTFLogoPanel"
+		"xpos"			"rs1"
+		"ypos"			"cs-0.5"
+		"zpos"			"5"
+		"wide"			"o1"
+		"tall"			"f0"
+		"visible"		"1"
+		"proportionaltoparent"	"1"
+
+		"radius"		"8"
+		"velocity"		"100"
+
+		"fgcolor_override"	"TFOrange"
+	}
+
+	"QueueText"
+	{
+		"ControlName"	"Label"
+		"fieldName"		"QueueText"
+		"xpos"			"rs1-18"
+		"ypos"			"cs-0.5"
+		"wide"			"f35"
+		"zpos"			"100"
+		"tall"			"f0"
+		"visible"		"1"
+		"enabled"		"1"
+		"font"			"AchievementTracker_Name"
+		"fgcolor_override"	"TanLight"
+		"textAlignment"	"east"
+		"labelText"		"%queue_state%"
+		"proportionaltoparent"	"1"
+		"mouseinputenabled"	"0"
+	}
+}

--- a/resource/ui/ingamequeuestatus.res
+++ b/resource/ui/ingamequeuestatus.res
@@ -7,7 +7,7 @@
 		"enabled"				"1"
 		"xpos"					"rs1-5"
 		"ypos"					"1"
-		"zpos"					"1001"
+		"zpos"					"2"
 		"wide"					"200"
 		"tall"					"18"
 		"proportionaltoparent"	"1"

--- a/scripts/hudlayout.res
+++ b/scripts/hudlayout.res
@@ -1474,7 +1474,7 @@
 		"enabled"				"1"
 		"xpos"					"0"
 		"ypos"					"0"
-		"zpos"					"1002"
+		"zpos"					"3"
 		"wide"					"f0"
 		"tall"					"f0"
 	}


### PR DESCRIPTION
in 4:3 aspect ratio

You wanted to solve this problem without adding new files, but unfortunately this is not possible because I found another problem, koth timer overlap, and without adding a new file it cannot be solved, so I reverted everything I changed to default and used my first solution I suggested to you earlier https://github.com/CriticalFlaw/TF2HUD.Fixes/pull/247