### PR TITLE
Restore RDScorePulse Color Change

### DIFF
--- a/scripts/hudanimations_custom.txt
+++ b/scripts/hudanimations_custom.txt
@@ -100,5 +100,20 @@ event TeamStatus_PlayerAlive
 
 //==================================================================================
 
-event RDPositiveScorePulse { }
-event RDNegativeScorePulse { }
+event RDPositiveScorePulse
+{
+	Animate Score FgColor	"25 255 25 255"		Linear 0.0 0.0
+	Animate Score FgColor	"TanLight"			Linear 0.1 0.2	
+
+	Animate ScoreShadow FgColor	"0 0 0 200"		Deaccel 0.0 0.05
+	Animate ScoreShadow FgColor	"Black"			Accel 0.1 0.2
+}
+
+event RDNegativeScorePulse
+{
+	Animate Score FgColor	"255 75 75 255"		Linear 0.0 0.0
+	Animate Score FgColor	"TanLight"			Linear 0.1 0.2
+
+	Animate ScoreShadow FgColor	"0 0 0 200"		Deaccel 0.0 0.05
+	Animate ScoreShadow FgColor	"Black"			Accel 0.1 0.2
+}


### PR DESCRIPTION
While the movement part of the animation needed to be removed for minmode (See #84) I feel that the color change of the animation should be added back

Before: 

https://github.com/user-attachments/assets/17ff2024-d422-4905-99a7-74ab8befa5cc

After:

https://github.com/user-attachments/assets/0d20013e-a681-401b-b0d3-a0608518a1f8


Also note: I swapped out the 0 0 0 255 of the shadow in the animation to its fgcolor (Black) as specified in hudobjectiveplayerdestruction.res / hudobjectiverobotdestruction.res