### PR TITLE
Correct killfeed rows button 9 command

### DIFF
--- a/resource/ui/#customizations/hud_customization_killfeed.res
+++ b/resource/ui/#customizations/hud_customization_killfeed.res
@@ -256,7 +256,7 @@
 						"labelText"							"9"
 						"font"								"ItemFontNameSmall"
 						"textAlignment"						"center"
-						"Command"							"engine hud_killfeed_rows_8"
+						"Command"							"engine hud_killfeed_rows_9"
 						"actionsignallevel"					"5"
 						"sound_depressed"					"UI/buttonclick.wav"
 


### PR DESCRIPTION
I noticed the settings stored for 9 killfeed rows were the same as 8 killfeed rows. Surpisingly this has been like this for ~2 years according to git's blame view.