### PR TITLE
Fix arena notification warning label

### DIFF
--- a/_fixes/resource/ui/hudarenanotification.res
+++ b/_fixes/resource/ui/hudarenanotification.res
@@ -1,0 +1,9 @@
+// Fix warning label cutting off 
+
+"Resource/UI/HudArenaNotification.res"
+{
+	"WarningLabel"
+	{	
+		"tall"			"55"
+	}
+}

--- a/resource/ui/hudarenanotification.res
+++ b/resource/ui/hudarenanotification.res
@@ -1,0 +1,2 @@
+#base	"../../_fixes/resource/ui/hudarenanotification.res"
+#base	"../../_tf2hud/resource/ui/hudarenanotification.res"


### PR DESCRIPTION
A very minor fix for a very minor issue: the warning label (exclamation mark) is cut off in the arena notification panel (this notification appears when no one else is on the server). This is due to a duplication of the `tall` value in the original file `hudarenanotification.res.`

Before:

![warning_label_before](https://github.com/user-attachments/assets/07be9566-e959-43ee-9697-b5c00649d511)

After:

![warning_label_after](https://github.com/user-attachments/assets/a9661b29-edf3-4ba3-9842-f3241703bcad)