### PR TITLE
Fixes the position of the briefcase in Mann vs. Machine minmode HUD

### DIFF
--- a/_fixes/resource/ui/flagstatus.res
+++ b/_fixes/resource/ui/flagstatus.res
@@ -18,8 +18,8 @@
 		
 		"if_mvm"
 		{
-			"xpos_minmode"	"57"
-			"ypos_minmode"	"15"
+			"xpos_minmode"	"59"
+			"ypos_minmode"	"21"
 			"wide_minmode"	"30"
 			"tall_minmode"	"30"
 		}


### PR DESCRIPTION
The briefcase icon appears stretched in Mann vs. Machine. I don't know if this is intentional, but before the #base redesign of the HUD, the `flagstatus.res` file contained two `wide_minmode` values for the `Briefcase` element.
https://github.com/CriticalFlaw/tf2hud-fixes/blob/eaa12d153ff49cda0852c2d4ce83116436f21fd7/resource/ui/flagstatus.res#L43

I also repositioned the icon so that it is more or less centered in the compass, because changing the tall value moved it.

Before:
![briefcase_mvm_before](https://github.com/user-attachments/assets/eeed1d3e-199e-4d01-83ea-e420825cc2bc)

After:
![briefcase_mvm_after](https://github.com/user-attachments/assets/4291c881-e0e0-47dd-913c-c94c4b00b687)
