### PR TITLE
fix CurrencyStatusPanel being drawn behind health and player on Linux

### DIFF
--- a/_tf2hud/scripts/hudlayout.res
+++ b/_tf2hud/scripts/hudlayout.res
@@ -361,6 +361,7 @@
 		"fieldName"			"CurrencyStatusPanel"
 		"xpos"				"0"
 		"ypos"				"r100"
+		"zpos"				"1"
 		"wide"				"100"
 		"tall"				"100"
 		"xpos_minmode"		"65"


### PR DESCRIPTION
On Linux clients, the CurrencyStatusPanel is drawn behind the health/player panel. Giving it a "zpos" of "1" resolves this issue.

<img width="640" height="480" alt="moneybegood01" src="https://github.com/user-attachments/assets/b298fc56-fcca-4ee9-8849-b70a3b7e01ad" />
<img width="640" height="480" alt="moneybegood02" src="https://github.com/user-attachments/assets/fe7a1249-96de-4848-a4dc-aa054d1aca9c" />
