### PR TITLE
Fixed alignment issues

### DIFF
--- a/_fixes/resource/ui/freezepanel_basic.res
+++ b/_fixes/resource/ui/freezepanel_basic.res
@@ -11,14 +11,20 @@
 	}
 	"FreezePanelBase"	[$WIN32]
 	{
+		
+		"FreezeLabel"
+		{
+			"xpos"			"45"
+		}
+
 		"FreezeLabelKiller"	
 		{	
-			"xpos"			"48"
+			"xpos"			"53"
 		}
 
 		"AvatarImage"
 		{
-			"xpos"			"40"
+			"xpos"			"45"
 		}	
 
 		"FreezePanelHealth"

--- a/_fixes/resource/ui/freezepanel_basic.res
+++ b/_fixes/resource/ui/freezepanel_basic.res
@@ -9,9 +9,9 @@
 		"model_wide"		"80"
 		"model_tall"		"50"
 	}
+
 	"FreezePanelBase"	[$WIN32]
 	{
-		
 		"FreezeLabel"
 		{
 			"xpos"			"45"
@@ -19,7 +19,7 @@
 
 		"FreezeLabelKiller"	
 		{	
-			"xpos"			"53"
+			"xpos"			"54"
 		}
 
 		"AvatarImage"
@@ -29,7 +29,10 @@
 
 		"FreezePanelHealth"
 		{
+			"xpos"			"9"
 			"ypos"			"161"
+			"wide"			"32"
+			"tall"			"32"
 		}	
 	}
 }

--- a/_fixes/resource/ui/freezepanel_basic.res
+++ b/_fixes/resource/ui/freezepanel_basic.res
@@ -1,4 +1,5 @@
 // Fix black bars appearing when inspecting skinned weapons
+// Fix alignment issues
 
 "resource/ui/freezepanel_basic.res"
 {
@@ -7,5 +8,22 @@
 		"model_ypos"		"20"
 		"model_wide"		"80"
 		"model_tall"		"50"
+	}
+	"FreezePanelBase"	[$WIN32]
+	{
+		"FreezeLabelKiller"	
+		{	
+			"xpos"			"48"
+		}
+
+		"AvatarImage"
+		{
+			"xpos"			"40"
+		}	
+
+		"FreezePanelHealth"
+		{
+			"ypos"			"161"
+		}	
 	}
 }

--- a/_fixes/resource/ui/mvmscoreboard.res
+++ b/_fixes/resource/ui/mvmscoreboard.res
@@ -26,7 +26,7 @@
 	}
 	"CreditStatsContainer"
 	{
-		"xpos"			"90"
+		"xpos"			"80"
 		"ypos"			"228"
 	}
 }

--- a/_fixes/resource/ui/mvmscoreboard.res
+++ b/_fixes/resource/ui/mvmscoreboard.res
@@ -1,27 +1,32 @@
 // Fix to accommodate large waves and bigger player teams (Fix by mtxfellen & impale1)
+// Fix alignment issues
 
 "resource/ui/mvmscoreboard.res"
 {
 	"WaveStatusPanel"
 	{
+		"xpos"			"20"
 		"ypos"			"13"
 	}
 	"DifficultyContainer"
 	{
-		"xpos"			"475"
+		"xpos"			"465"
 		"ypos"			"240"
 	}
 	"PlayerListBackground"
 	{
+		"xpos"			"45"
 		"ypos"			"79"
 	}
 	"MvMPlayerList"
 	{
+		"xpos"			"55"
 		"ypos"			"83"
 		"tall"			"140"
 	}
 	"CreditStatsContainer"
 	{
+		"xpos"			"90"
 		"ypos"			"228"
 	}
 }

--- a/_fixes/resource/ui/winpanel.res
+++ b/_fixes/resource/ui/winpanel.res
@@ -1,0 +1,122 @@
+// Fix alignment issues (#371)
+
+"resource/ui/winpanel.res"
+{
+	"ShadedBar"
+	{
+		"xpos"			"cs-0.5"
+		"proportionaltoparent"	"1"
+	}
+	"TopPlayersLabel"
+	{	
+		"xpos"			"20"
+		"proportionaltoparent"	"1"
+	}
+	"PointsThisRoundLabel"
+	{	
+		"xpos"			"rs1-20"
+		"proportionaltoparent"	"1"
+	}
+	"HorizontalLine"
+	{
+		"xpos"			"cs-0.5"
+		"proportionaltoparent"	"1"
+	}
+	"Player1Badge"
+	{
+		"xpos"			"13"
+	}
+	"Player1Avatar"
+	{
+		"xpos"			"41"
+	}
+	"Player1Name"
+	{	
+		"xpos"			"58"
+	}
+	"Player1Class"
+	{	
+		"xpos"			"185"
+	}
+	"Player1Score"
+	{	
+		"xpos"			"245"
+	}
+	"Player2Badge"
+	{
+		"xpos"			"13"
+	}
+	"Player2Avatar"
+	{
+		"xpos"			"41"
+	}
+	"Player2Name"
+	{	
+		"xpos"			"58"
+	}
+	"Player2Class"
+	{	
+		"xpos"			"185"
+	}
+	"Player2Score"
+	{	
+		"xpos"			"245"
+	}	
+	"Player3Badge"
+	{
+		"xpos"			"13"
+	}
+	"Player3Avatar"
+	{
+		"xpos"			"41"
+	}
+	"Player3Name"
+	{	
+		"xpos"			"58"
+	}
+	"Player3Class"
+	{	
+		"xpos"			"185"
+	}
+	"Player3Score"
+	{	
+		"xpos"			"245"
+	}
+
+	// KillStreak
+	"KillStreakLeaderLabel"
+	{	
+		"xpos"			"20"
+		"proportionaltoparent"	"1"
+	}
+	"KillStreakMaxCountLabel"
+	{	
+		"xpos"			"rs1-20"
+		"proportionaltoparent"	"1"
+	}
+	"HorizontalLine2"
+	{
+		"xpos"			"cs-0.5"
+		"proportionaltoparent"	"1"
+	}
+	"KillstreakPlayer1Badge"
+	{
+		"xpos"			"13"
+	}
+	"KillstreakPlayer1Avatar"
+	{
+		"xpos"			"41"
+	}
+	"KillstreakPlayer1Name"
+	{	
+		"xpos"			"58"
+	}
+	"KillstreakPlayer1Class"
+	{	
+		"xpos"			"185"
+	}
+	"KillstreakPlayer1Score"
+	{	
+		"xpos"			"245"
+	}
+}

--- a/resource/ui/winpanel.res
+++ b/resource/ui/winpanel.res
@@ -1,0 +1,2 @@
+#base	"../../_fixes/resource/ui/winpanel.res"
+#base	"../../_tf2hud/resource/ui/winpanel.res"


### PR DESCRIPTION
Fixes #371 

For the scoreboard I decided to move the playerlist and wave panel right by 20 units and opted to move the credits and difficulty panels to make them align with the rest better.

Checked on 16:9 (1920x1080) and 4:3 (1440x1080)

